### PR TITLE
Add Claude session setup to auto-stage plugin contents

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+plugins/

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+make setup

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,23 @@ DEV_PLUGIN_NAME := kata-dev
 DEV_MARKETPLACE_NAME := 0k-software-dev
 DEV_MARKETPLACE_DIR := dev
 
+PLUGIN_STAGE_DIR := .claude/plugins/$(PLUGIN_NAME)
+
 .PHONY: all
 all: install-plugin
+
+# Stage the plugin contents under .claude/plugins/<name>/ so Claude Code can
+# discover the kata skills inside this session. Excludes .git and .claude
+# itself to avoid recursion. Idempotent — safe to re-run.
+.PHONY: setup
+setup:
+	@rm -rf $(PLUGIN_STAGE_DIR)
+	@mkdir -p $(PLUGIN_STAGE_DIR)
+	@find . -mindepth 1 -maxdepth 1 \
+		-not -name '.git' \
+		-not -name '.claude' \
+		-exec cp -a {} $(PLUGIN_STAGE_DIR)/ \;
+	@echo "Staged plugin contents at $(PLUGIN_STAGE_DIR)/"
 
 # Installs from the local working copy under a separate
 # `kata-dev@0k-software-dev` identity so it never clobbers a developer's


### PR DESCRIPTION
## Summary
This PR adds automatic plugin staging functionality that runs when Claude sessions start, enabling Claude Code to discover kata skills within the development environment.

## Key Changes
- **Added `setup` Makefile target**: Stages plugin contents under `.claude/plugins/<name>/` by copying all project files (excluding `.git` and `.claude` directories) to prevent recursion. The target is idempotent and safe to re-run.
- **Added `.claude/settings.json`**: Configures Claude to execute a session start hook that automatically runs the setup process.
- **Added `.claude/hooks/session-start.sh`**: Shell script that triggers `make setup` when a Claude session starts, ensuring the plugin is always staged and discoverable.
- **Added `.claude/.gitignore`**: Excludes the `plugins/` directory from version control since it contains generated staging artifacts.

## Implementation Details
The setup process uses `find` with `-mindepth` and `-maxdepth` flags to copy only top-level project contents, while explicitly excluding `.git` and `.claude` directories to avoid infinite recursion and unnecessary duplication. The hook is automatically invoked on session start, making the plugin discovery seamless for developers working in Claude Code.

https://claude.ai/code/session_012R4DVDKgbQtTeJyV7ohTMA