### PR TITLE
Update kata plugin description with dojo metaphor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "description": "0k-software org skills — commit, rebase, issue management, branch workflows, and more",
+  "description": "Send your coding agents to the dojo to earn their belt: make them learn to fight for a better software development process.",
   "version": "1.0.0",
   "author": { "name": "0k-software" },
   "license": "MIT",

--- a/.claude/plugins/kata/.claude-plugin/plugin.json
+++ b/.claude/plugins/kata/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "description": "0k-software org skills — commit, rebase, issue management, branch workflows, and more",
+  "description": "Send your coding agents to the dojo to earn their belt: make them learn to fight for a better software development process.",
   "version": "1.0.0",
   "author": { "name": "0k-software" },
   "license": "MIT",


### PR DESCRIPTION
## Summary
Updated the plugin description for the kata plugin to use a more engaging and metaphorical approach that emphasizes the learning and skill-building aspects of the software development process.

## Changes
- Replaced the technical description "0k-software org skills — commit, rebase, issue management, branch workflows, and more" with a more evocative description: "Send your coding agents to the dojo to earn their belt: make them learn to fight for a better software development process."
- Updated description in both `.claude-plugin/plugin.json` and `.claude/plugins/kata/.claude-plugin/plugin.json` to maintain consistency across plugin configuration files

## Details
The new description uses a martial arts dojo metaphor to convey that the kata plugin is a training tool for coding agents to develop and master software development practices. This provides a clearer, more memorable value proposition while maintaining the core message about skill development.

https://claude.ai/code/session_01GUEckhkHUkwkQzWnNd3y7h