### PR TITLE
Update release process and bump version to 0.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kata",
   "description": "Send your coding agents to the dojo to earn their belt: make them learn to fight for a better software development process.",
-  "version": "1.0.1",
+  "version": "0.1.0",
   "author": { "name": "0k-software" },
   "license": "MIT",
   "homepage": "https://github.com/0k-software/kata",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kata",
   "description": "Send your coding agents to the dojo to earn their belt: make them learn to fight for a better software development process.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": { "name": "0k-software" },
   "license": "MIT",
   "homepage": "https://github.com/0k-software/kata",

--- a/README.md
+++ b/README.md
@@ -191,8 +191,11 @@ the skill — edits to `SKILL.md` are picked up on the next call.
 ## Releasing a new version
 
 1. Bump `version` in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)
-   and commit.
-2. Run `make release`. This validates the working tree is clean, creates and
+   and update the changelog.
+2. Open a PR with the bump and changelog updates, get it reviewed, and merge to
+   `main`.
+3. Check out `main` and pull the merged changes.
+4. Run `make release`. This validates the working tree is clean, creates and
    pushes the `v$VERSION` tag, and publishes a GitHub release with
    auto-generated notes. Claude Code picks up the new version on its next
    `/plugin update` check.


### PR DESCRIPTION
## Summary
This PR updates the release process documentation to include a PR review step before running the release command, and bumps the plugin version to 0.1.0 to reflect the project's current maturity level.

## Key Changes
- **Release process documentation**: Updated the release instructions to require opening a PR for version bumps and changelog updates, getting it reviewed, and merging to `main` before running `make release`. This ensures changes are reviewed before release.
- **Version bump**: Downgraded version from 1.0.0 to 0.1.0 in `.claude-plugin/plugin.json` to better reflect the project's current state as a pre-1.0 release.
- **Changelog requirement**: Added explicit instruction to update the changelog when bumping the version.

## Notable Details
The release process now follows a more standard workflow:
1. Bump version and update changelog
2. Open PR for review and merge to `main`
3. Pull merged changes locally
4. Run `make release` to create the tag and GitHub release

This ensures all release-related changes are reviewed before the automated release process is triggered.

https://claude.ai/code/session_01Cj32SEZSNMUz8BgBTa1kpz