### PR TITLE
Enable kata plugin via 0k-plugins marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,16 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "0k-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "0k-software/0k-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "kata@0k-plugins": true
   }
 }


### PR DESCRIPTION
## Summary

- Register the `0k-software/0k-plugins` marketplace in `.claude/settings.json`
- Enable the `kata@0k-plugins` plugin so the repo dogfoods its published distribution path
