### PR TITLE
Auto-install kata plugin during session setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,14 +4,3 @@ set -euo pipefail
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 make setup
-
-# Marketplace is registered via extraKnownMarketplaces in .claude/settings.json,
-# but that only makes Claude Code aware of it — the plugin still has to be
-# installed from it before its /kata:* skills resolve.
-if command -v claude >/dev/null 2>&1; then
-    installed_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
-    if ! jq -e '.plugins["kata@0k-plugins"]' "$installed_file" >/dev/null 2>&1; then
-        echo "Installing kata@0k-plugins..."
-        claude plugin install kata@0k-plugins
-    fi
-fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,3 +4,14 @@ set -euo pipefail
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 make setup
+
+# Marketplace is registered via extraKnownMarketplaces in .claude/settings.json,
+# but that only makes Claude Code aware of it — the plugin still has to be
+# installed from it before its /kata:* skills resolve.
+if command -v claude >/dev/null 2>&1; then
+    installed_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
+    if ! jq -e '.plugins["kata@0k-plugins"]' "$installed_file" >/dev/null 2>&1; then
+        echo "Installing kata@0k-plugins..."
+        claude plugin install kata@0k-plugins
+    fi
+fi

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,25 @@ PLUGIN_VERSION := $(shell jq -r '.version' .claude-plugin/plugin.json 2>/dev/nul
 # Install repo-managed git hooks from .git-hooks/ into the local .git/hooks/
 # directory. Idempotent — safe to re-run; copies overwrite previous installs.
 .PHONY: setup
-setup:
+setup: plugins
 	@test -d .git || { echo "error: not a git working tree"; exit 1; }
 	@for hook in .git-hooks/*; do \
 		install -m 755 "$$hook" ".git/hooks/$$(basename $$hook)"; \
 	done
 	@echo "Installed git hooks from .git-hooks/"
+
+# Ensure plugins enabled in .claude/settings.json are actually installed.
+# extraKnownMarketplaces registers a marketplace, but plugins still need to
+# be installed from it before their skills resolve.
+.PHONY: plugins
+plugins:
+	@if command -v claude >/dev/null 2>&1; then \
+		installed="$${CLAUDE_CONFIG_DIR:-$$HOME/.claude}/plugins/installed_plugins.json"; \
+		if ! jq -e '.plugins["kata@0k-plugins"]' "$$installed" >/dev/null 2>&1; then \
+			echo "Installing kata@0k-plugins..."; \
+			claude plugin install kata@0k-plugins; \
+		fi; \
+	fi
 
 .PHONY: release
 release:


### PR DESCRIPTION
## Summary
Added automatic installation of the `kata@0k-plugins` plugin during the session startup process to ensure the plugin is available before its `/kata:*` skills are needed.

## Changes
- Extended the `session-start.sh` hook to check if the kata plugin is installed
- If the plugin is not found in the installed plugins registry, automatically install it using the `claude plugin install` command
- The installation only runs if the `claude` CLI is available on the system
- Added explanatory comments clarifying why this step is necessary (the marketplace registration alone doesn't install the plugin)

## Implementation Details
- Uses `jq` to query the `installed_plugins.json` file for the presence of `kata@0k-plugins`
- Gracefully handles cases where the `claude` command is not available
- Only attempts installation if the plugin is not already installed, avoiding redundant operations

https://claude.ai/code/session_01Se8WYjJx3qhxLygyEUHCm1