### PR TITLE
Refactor setup target and fix plugin marketplace registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,17 @@ setup: plugins
 	@echo "Installed git hooks from .git-hooks/"
 
 # Ensure plugins enabled in .claude/settings.json are actually installed.
-# extraKnownMarketplaces registers a marketplace, but plugins still need to
-# be installed from it before their skills resolve.
+# The harness registers extraKnownMarketplaces lazily (after SessionStart
+# hooks fire), so we register the marketplace ourselves before installing —
+# otherwise `claude plugin install` errors with "not found in marketplace".
 .PHONY: plugins
 plugins:
 	@if command -v claude >/dev/null 2>&1; then \
+		known="$${CLAUDE_CONFIG_DIR:-$$HOME/.claude}/plugins/known_marketplaces.json"; \
+		if ! jq -e '."0k-plugins"' "$$known" >/dev/null 2>&1; then \
+			echo "Registering 0k-plugins marketplace..."; \
+			claude plugin marketplace add 0k-software/0k-plugins; \
+		fi; \
 		installed="$${CLAUDE_CONFIG_DIR:-$$HOME/.claude}/plugins/installed_plugins.json"; \
 		if ! jq -e '.plugins["kata@0k-plugins"]' "$$installed" >/dev/null 2>&1; then \
 			echo "Installing kata@0k-plugins..."; \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 PLUGIN_VERSION := $(shell jq -r '.version' .claude-plugin/plugin.json 2>/dev/null)
 
+.PHONY: setup
+setup: git-hooks install-plugins
+
 # Install repo-managed git hooks from .git-hooks/ into the local .git/hooks/
 # directory. Idempotent — safe to re-run; copies overwrite previous installs.
-.PHONY: setup
-setup: plugins
+.PHONY: git-hooks
+git-hooks:
 	@test -d .git || { echo "error: not a git working tree"; exit 1; }
 	@for hook in .git-hooks/*; do \
 		install -m 755 "$$hook" ".git/hooks/$$(basename $$hook)"; \
@@ -14,8 +17,8 @@ setup: plugins
 # The harness registers extraKnownMarketplaces lazily (after SessionStart
 # hooks fire), so we register the marketplace ourselves before installing —
 # otherwise `claude plugin install` errors with "not found in marketplace".
-.PHONY: plugins
-plugins:
+.PHONY: install-plugins
+install-plugins:
 	@if command -v claude >/dev/null 2>&1; then \
 		known="$${CLAUDE_CONFIG_DIR:-$$HOME/.claude}/plugins/known_marketplaces.json"; \
 		if ! jq -e '."0k-plugins"' "$$known" >/dev/null 2>&1; then \


### PR DESCRIPTION
## Summary
Restructured the Makefile setup process to separate git hooks installation from plugin management, and added explicit marketplace registration before plugin installation to prevent "not found in marketplace" errors.

## Key Changes
- Split the `setup` target into two distinct targets: `git-hooks` and `install-plugins`
- Renamed `plugins` target to `install-plugins` for clarity
- Added marketplace registration step that runs before plugin installation
  - Checks if the `0k-plugins` marketplace is already registered in `known_marketplaces.json`
  - Registers the marketplace via `claude plugin marketplace add` if not present
  - This prevents errors when `claude plugin install` is called before the harness registers the marketplace
- Updated comments to explain the lazy marketplace registration behavior and why we need to register it ourselves

## Implementation Details
The key insight is that the Claude harness registers `extraKnownMarketplaces` lazily (after SessionStart hooks fire), but plugin installation happens before that. By explicitly registering the marketplace in the setup phase, we ensure plugins can be found and installed successfully without errors.

https://claude.ai/code/session_01QCAhENux9n2Z6J3c71V5pu